### PR TITLE
Fix: Add all contributors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ _"Supporting those who served, one connection at a time."_
 - Benjamin Parrish
 - Rodel Advincula
 - Michael Sigg
+- Matt Norris


### PR DESCRIPTION
Cherry-picked Matt's commit and fixed formatting issue
- Added Matt Norris to contributors list  
- Fixed formatting where names were concatenated
- All 6 team members now properly listed